### PR TITLE
cksum is computed incorrectly

### DIFF
--- a/cksum.c
+++ b/cksum.c
@@ -9,7 +9,6 @@
 __u16 cksum(__u16 *buf, int nbytes)
 {
 	__u32 sum;
-	__u16 oddbyte;
 
 	sum = 0;
 	while (nbytes > 1) {
@@ -18,9 +17,7 @@ __u16 cksum(__u16 *buf, int nbytes)
 	}
 
 	if (nbytes == 1) {
-		oddbyte = 0;
-		*((__u16 *) &oddbyte) = *(__u16 *) buf;
-		sum += oddbyte;
+		sum += *((__u8*)buf);
 	}
 
 	sum = (sum >> 16) + (sum & 0xffff);


### PR DESCRIPTION
The previous code read off the end of *buf, and also produced incorrect TCP checksums, when nbytes was odd.
