### PR TITLE
Add SO_BINDTODEVICE to fix -I option

### DIFF
--- a/hping2.h
+++ b/hping2.h
@@ -399,6 +399,7 @@ void	datafiller(char *p, int size);		/* fill data from file */
 void	data_handler(char *data, int data_size);/* handle data filling */
 void	socket_broadcast(int sd);		/* set SO_BROADCAST option */
 void	socket_iphdrincl(int sd);		/* set SO_IPHDRINCL option */
+void socket_bindtodevice(int sd);               /* set SO_BINDTODEVICE option */
 void	listenmain(void);			/* main for listen mode */
 char	*memstr(char *haystack, char *needle, int size); /* memstr */
 void	tos_help(void);				/* show the TOS help */

--- a/main.c
+++ b/main.c
@@ -247,6 +247,8 @@ int main(int argc, char **argv)
 	socket_broadcast(sockraw);
 	/* set SO_IPHDRINCL option */
 	socket_iphdrincl(sockraw);
+	/* set SO_BINDTODEVICE option */
+	socket_bindtodevice(sockraw);
 
 	/* open sock packet or libpcap socket */
 	if (open_pcap() == -1) {

--- a/sockopt.c
+++ b/sockopt.c
@@ -13,7 +13,13 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h> /* IP_PROTOIP */
+#include <linux/sockios.h>
+#include <net/if.h>
 #include <stdio.h>
+#include <sys/ioctl.h>
+
+#include "hping2.h"
+#include "globals.h"
 
 void socket_broadcast(int sd)
 {
@@ -36,5 +42,16 @@ void socket_iphdrincl(int sd)
 	{
 		printf("[socket_iphdrincl] can't set IP_HDRINCL option\n");
 		/* non fatal error */
+	}
+}
+
+void socket_bindtodevice(int sd) 
+{
+	struct ifreq ifr;
+	strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+	ioctl(sd, SIOCGIFINDEX, &ifr);
+	if(setsockopt(sd, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr,
+		      sizeof(ifr)) == -1) {
+		printf("BINDTODEVICE failed");
 	}
 }

--- a/sockopt.c
+++ b/sockopt.c
@@ -45,13 +45,13 @@ void socket_iphdrincl(int sd)
 	}
 }
 
-void socket_bindtodevice(int sd) 
+void socket_bindtodevice(int sd)
 {
 	struct ifreq ifr;
 	strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
 	ioctl(sd, SIOCGIFINDEX, &ifr);
 	if(setsockopt(sd, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr,
 		      sizeof(ifr)) == -1) {
-		printf("BINDTODEVICE failed");
+		printf("BINDTODEVICE failed\n");
 	}
 }


### PR DESCRIPTION
During my testing the -I switch did not seem to affect which interface traffic came through if there was not a routing table difference between the interfaces. With this change, traffic does flow through the specified interface.

I believe this is also correct if no -I option is specified (the ifname variable is populated earlier regardless)
