### PR TITLE
Added cmd option --icmp-echoid

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -114,6 +114,7 @@ extern int	opt_debug,
 		opt_force_icmp,
 		icmp_ip_protocol,
 		icmp_cksum,
+		icmp_echoid,
 		raw_ip_protocol;
 
 extern unsigned char 	lsr[255],

--- a/hping2.h
+++ b/hping2.h
@@ -123,6 +123,7 @@
 #define DEFAULT_ICMP_IP_TOT_LEN		0 /* computed by send_icmp_*() */
 #define DEFAULT_ICMP_IP_ID		0 /* rand */
 #define DEFAULT_ICMP_CKSUM		-1 /* -1 means compute the cksum */
+#define DEFAULT_ICMP_ECHOID             -1 /* getpid() & 0xffff */
 #define DEFAULT_ICMP_IP_PROTOCOL	6 /* TCP */
 #define DEFAULT_RAW_IP_PROTOCOL		6 /* TCP */
 #define DEFAULT_TRACEROUTE_TTL		1

--- a/main.c
+++ b/main.c
@@ -133,6 +133,7 @@ int
 	icmp_ip_dstport	= DEFAULT_DPORT,
 	opt_force_icmp  = FALSE,
 	icmp_cksum	= DEFAULT_ICMP_CKSUM,
+	icmp_echoid     = DEFAULT_ICMP_ECHOID,
 	raw_ip_protocol	= DEFAULT_RAW_IP_PROTOCOL;
 
 char

--- a/parseoptions.c
+++ b/parseoptions.c
@@ -36,7 +36,7 @@ enum {	OPT_COUNT, OPT_INTERVAL, OPT_NUMERIC, OPT_QUIET, OPT_INTERFACE,
 	OPT_ICMP_IPSRC, OPT_ICMP_IPDST, OPT_ICMP_SRCPORT, OPT_ICMP_DSTPORT,
 	OPT_ICMP_GW, OPT_FORCE_ICMP, OPT_APD_SEND, OPT_SCAN, OPT_FASTER,
 	OPT_BEEP, OPT_FLOOD, OPT_CLOCK_SKEW, OPT_CS_WINDOW, OPT_CS_WINDOW_SHIFT,
-        OPT_CS_VECTOR_LEN };
+        OPT_CS_VECTOR_LEN, OPT_ICMP_ECHOID };
 
 static struct ago_optlist hping_optlist[] = {
 	{ 'c',	"count",	OPT_COUNT,		AGO_NEEDARG },
@@ -102,6 +102,7 @@ static struct ago_optlist hping_optlist[] = {
 	{ '\0',	"icmp-ipid",	OPT_ICMP_IPID,	 	AGO_NEEDARG|AGO_EXCEPT0 },
 	{ '\0',	"icmp-ipproto",	OPT_ICMP_IPPROTO, 	AGO_NEEDARG|AGO_EXCEPT0 },
 	{ '\0', "icmp-cksum",	OPT_ICMP_CKSUM,   	AGO_NEEDARG|AGO_EXCEPT0 },
+	{ '\0', "icmp-echoid",  OPT_ICMP_ECHOID,        AGO_NEEDARG|AGO_EXCEPT0 },
 	{ '\0',	"icmp-ts",	OPT_ICMP_TS,		AGO_NOARG },
 	{ '\0', "icmp-addr",	OPT_ICMP_ADDR,		AGO_NOARG },
 	{ '\0', "tcpexitcode",	OPT_TCPEXITCODE,	AGO_NOARG },
@@ -492,6 +493,9 @@ int parse_options(int argc, char **argv)
 			break;
 		case OPT_ICMP_CKSUM:
 			icmp_cksum = strtol(ago_optarg, NULL, 0);
+			break;
+		case OPT_ICMP_ECHOID:
+			icmp_echoid = strtol(ago_optarg, NULL, 0);
 			break;
 		case OPT_TCPEXITCODE:
 			opt_tcpexitcode = TRUE;

--- a/sendicmp.c
+++ b/sendicmp.c
@@ -83,7 +83,7 @@ void send_icmp_echo(void)
 	icmp->type = opt_icmptype;	/* echo replay or echo request */
 	icmp->code = opt_icmpcode;	/* should be indifferent */
 	icmp->checksum = 0;
-	icmp->un.echo.id = getpid() & 0xffff;
+	icmp->un.echo.id = htons(icmp_echoid == -1 ? (getpid() & 0xffff) : icmp_echoid);
 	icmp->un.echo.sequence = _icmp_seq;
 
 	/* data */
@@ -127,7 +127,7 @@ void send_icmp_timestamp(void)
 	icmp->type = opt_icmptype;	/* echo replay or echo request */
 	icmp->code = 0;
 	icmp->checksum = 0;
-	icmp->un.echo.id = getpid() & 0xffff;
+	icmp->un.echo.id = htons(icmp_echoid == -1 ? (getpid() & 0xffff) : icmp_echoid);
 	icmp->un.echo.sequence = _icmp_seq;
 	tstamp_data->orig = htonl(get_midnight_ut_ms());
 	tstamp_data->recv = tstamp_data->tran = 0;
@@ -169,7 +169,7 @@ void send_icmp_address(void)
 	icmp->type = opt_icmptype;	/* echo replay or echo request */
 	icmp->code = 0;
 	icmp->checksum = 0;
-	icmp->un.echo.id = getpid() & 0xffff;
+	icmp->un.echo.id = htons(icmp_echoid == -1 ? (getpid() & 0xffff) : icmp_echoid);
 	icmp->un.echo.sequence = _icmp_seq;
 	memset(packet+ICMPHDR_SIZE, 0, 4);
 
@@ -230,7 +230,7 @@ void send_icmp_other(void)
 	icmp_ip.ihl      = icmp_ip_ihl;			/* IPHDR_SIZE >> 2 */
 	icmp_ip.tos      = icmp_ip_tos;			/* 0 */
 	icmp_ip.tot_len  = htons((icmp_ip_tot_len ? icmp_ip_tot_len : (icmp_ip_ihl<<2) + UDPHDR_SIZE + udp_data_len));
-	icmp_ip.id       = htons(getpid() & 0xffff);
+	icmp_ip.id       = htons(icmp_echoid == -1 ? (getpid() & 0xffff) : icmp_echoid);
 	icmp_ip.frag_off = 0;				/* 0 */
 	icmp_ip.ttl      = 64;				/* 64 */
 	icmp_ip.protocol = icmp_ip_protocol;		/* 6 (TCP) */

--- a/usage.c
+++ b/usage.c
@@ -140,6 +140,7 @@ void icmp_help(void)
 "  --icmp-srcport   set tcp/udp source port      ( default random )\n"
 "  --icmp-dstport   set tcp/udp destination port ( default random )\n"
 "  --icmp-cksum     set icmp checksum            ( default the right cksum)\n"
+"  --icmp-echoid    set icmp echo id             ( default pid & 0xffff )\n"
 	);
 	exit(0);
 }

--- a/waitpacket.c
+++ b/waitpacket.c
@@ -243,7 +243,7 @@ int recv_icmp(void *packet, size_t size)
 	if ((icmp.type == ICMP_ECHOREPLY  ||
 	     icmp.type == ICMP_TIMESTAMPREPLY ||
 	     icmp.type == ICMP_ADDRESSREPLY) &&
-		icmp.un.echo.id == (getpid() & 0xffff))
+		icmp.un.echo.id == htons(icmp_echoid == -1 ? (getpid() & 0xffff) : icmp_echoid))
 	{
 		int icmp_seq = icmp.un.echo.sequence;
 		int status;


### PR DESCRIPTION
If --icmp-echoid not specified get pid as echo id

In previous version you set echo.id as getpid() instead of htons(getpid())
I suppose it is a bug and fix it.
