### PR TITLE
Add detection support of TCL versions 8.6 and 8.5

### DIFF
--- a/configure
+++ b/configure
@@ -63,7 +63,7 @@ esac
 #
 for TCLPATH_TRY in "/usr/bin/" "/usr/local/bin/" "/bin/"
 do
-	for TCLVER_TRY in "8.4" "8.3" "8.2" "8.1" "8.0"
+	for TCLVER_TRY in "8.6" "8.5" "8.4" "8.3" "8.2" "8.1" "8.0"
 	do
 		if [ -z $TCLSH ]
 		then
@@ -98,7 +98,7 @@ then
 fi
 if [ -n $USE_TCL ]
 then
-	LIBPOSTFIX=`ls -1 /usr/local/lib/ /usr/lib | grep 'libtcl[0-9]' | grep so | sed -e 's/\.so.*//g' -e 's/libtcl//g' | sort -r | head -1`
+	LIBPOSTFIX=`find /usr/local/lib/ /usr/lib -type f | grep "libtcl[0-9]" | grep so | sed -e 's/.*\///g' -e 's/\.so.*//g' -e 's/libtcl//g' | sort -r | head -1`
 	TCL_LIB="-ltcl${LIBPOSTFIX} -lm -lpthread"
 fi
 


### PR DESCRIPTION
In addition to adding labels "8.6" and "8.5" to the list of possible TCL versions, the patch also changes how `libtcl.so`if found. In my system (Ubuntu 18.04) `libtcl8.6.so` lives at `/usr/lib/x86_64-linux-gnu/`. Trying to figure out why is that I learned Debian and Ubuntu are moving now to a new multiarch implementation where mixed-architecture installations can be managed much more sanely [1], thus this new directory layout.

Basically the change does a recursive file search over two root directories and removes the dirname, leaving only the basename of the path. The rest is the same as before.

Regarding version 8.5, I added the label but I couldn't test it (since my system features 8.6).

[1] https://unix.stackexchange.com/questions/43190/where-did-usr-lib64-go-and-what-is-usr-lib-x86-64-linux-gnu