### PR TITLE
Use pcap/bpf.h if available

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,7 +9,7 @@
 CC= gcc
 AR=/usr/bin/ar
 RANLIB=/usr/bin/ranlib
-CCOPT= -O2 -Wall @PCAP_INCLUDE@ @TCL_INC@ @USE_TCL@
+CCOPT= -O2 -Wall @PCAP_INCLUDE@ @TCL_INC@ @USE_TCL@ @USE_PCAP_BPF@
 DEBUG= -g
 #uncomment the following if you need libpcap based build under linux
 #(not raccomanded)

--- a/configure
+++ b/configure
@@ -103,6 +103,14 @@ then
 fi
 
 #
+# PCAP_BPF detection
+#
+if [ -f "/usr/include/pcap/bpf.h" ]
+then
+   USE_PCAP_BPF="-DUSE_PCAP_BPF"
+fi
+
+#
 # configurable stuff
 #
 PCAP="PCAP=-lpcap"
@@ -140,6 +148,7 @@ sed	-e "s^@PCAP@^$PCAP^g" \
 	-e "s^@MANPATH@^$INSTALL_MANPATH^g" \
 	-e "s^@SOLARISLIB@^$SOLARISLIB^g" \
 	-e "s^@USE_TCL@^$USE_TCL^g" \
+	-e "s^@USE_PCAP_BPF@^$USE_PCAP_BPF^g" \
 	-e "s^@TCL_INC@^$TCL_INC^g" \
 	-e "s^@TCL_VER@^$TCL_VER^g" \
 	-e "s^@TCL_LIB@^$TCL_LIB^g" \

--- a/libpcap_stuff.c
+++ b/libpcap_stuff.c
@@ -16,7 +16,11 @@
 #include <string.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
+#ifdef USE_PCAP_BPF
+#include <pcap/bpf.h>
+#else
 #include <net/bpf.h>
+#endif
 #include <pcap.h>
 
 #include "globals.h"

--- a/script.c
+++ b/script.c
@@ -23,7 +23,13 @@
 #include <sched.h>
 
 #include <sys/ioctl.h>
+
+#ifdef USE_PCAP_BPF
+#include <pcap/bpf.h>
+#else
 #include <net/bpf.h>
+#endif
+
 #include <pcap.h>
 
 #include "release.h"


### PR DESCRIPTION
In my system `bpf.h` is provided by `pcap` and lives at `/usr/include/pcap/bpf.h`. Hping expects to find `bpf.h` at `net/bpf.h`.

The patch modified `configure` to check whether `/usr/include/pcap/bpf.h` and in that case defines a  defined (USE_PCAP_BPF), which is taking into account when importing `bpf.h`.