### PR TITLE
Redirect stderr to /dev/null on creating symbolic links

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -74,8 +74,8 @@ distclean:
 install: hping3
 	cp -f hping3 /usr/sbin/
 	chmod 755 /usr/sbin/hping3
-	ln -s /usr/sbin/hping3 /usr/sbin/hping
-	ln -s /usr/sbin/hping3 /usr/sbin/hping2
+	ln -s /usr/sbin/hping3 /usr/sbin/hping &> /dev/null
+	ln -s /usr/sbin/hping3 /usr/sbin/hping2 &> /dev/null
 	@if [ -d ${INSTALL_MANPATH}/man8 ]; then \
 		cp ./docs/hping3.8 ${INSTALL_MANPATH}/man8; \
 		chmod 644 ${INSTALL_MANPATH}/man8/hping3.8; \


### PR DESCRIPTION
When running `sudo make install` an Error is returned if `/sbin/hping/` already exists:

```bash
cp -f hping3 /usr/sbin/
chmod 755 /usr/sbin/hping3
ln -s /usr/sbin/hping3 /usr/sbin/hping
ln: failed to create symbolic link '/usr/sbin/hping': File exists
Makefile:75: recipe for target 'install' failed
make: *** [install] Error 1
```
The error message can be taken as an unsuccessful install. The patch redirects stderr to `/dev/null` to hide this error.