### PR TITLE
Uppercase the host argument to avoid confusing it with a sub-command.

### DIFF
--- a/docs/HPING2-HOWTO.txt
+++ b/docs/HPING2-HOWTO.txt
@@ -65,7 +65,7 @@ __0003: First step with hping
 
   The simplest usage of hping is the following:
 
-	#hping host
+	#hping HOST
 
   This command sends a TCP null-flags packet to port 0 of target
   host every second and show the host replies. For example:
@@ -437,4 +437,4 @@ round-trip min/avg/max = 0.0/0.0/0.0 ms
 
   Tips: Using an idle host to perform spoofed scanning it's usefull to
 	output only replies that show an increment != 1. Try
-	`hping host -r | grep -v "id=+1"'
+	`hping HOST -r | grep -v "id=+1"'

--- a/docs/french/HPING2-HOWTO.txt
+++ b/docs/french/HPING2-HOWTO.txt
@@ -72,7 +72,7 @@ __0003 : Premiers pas avec hping
 
   La plus simple utilisation de hping est la suivante :
 
-	#hping host
+	#hping HOST
 
   Cette commande envoie un paquet TCP sans drapeau au port 0 du système
   cible chaque seconde et montre les réponses du système. Par exemple :
@@ -472,4 +472,4 @@ round-trip min/avg/max = 0.0/0.0/0.0 ms
   Conseil : en utilisant un système inactif pour réaliser un scan usurpé il
             est utile de ne montrer que les réponses qui montrent un
             incrément différent de 1. Essayez
-            `hping host -r | grep -v "id=+1"'
+            `hping HOST -r | grep -v "id=+1"'

--- a/usage.c
+++ b/usage.c
@@ -16,7 +16,7 @@
 void	show_usage(void)
 {
 	printf(
-"usage: hping host [options]\n"
+"usage: hping HOST [options]\n"
 "  -h  --help      show this help\n"
 "  -v  --version   show version\n"
 "  -c  --count     packet count\n"


### PR DESCRIPTION
Argument names in usage strings or example commands are traditionally UPPERCASE.