### PR TITLE
hping: fix build against gcc-10 (-fno-common)

### DIFF
--- a/hping2.h
+++ b/hping2.h
@@ -357,7 +357,7 @@ struct delaytable_element {
 	int status;
 };
 
-volatile struct delaytable_element delaytable[TABLESIZE];
+extern volatile struct delaytable_element delaytable[TABLESIZE];
 
 /* protos */
 void	nop(void);				/* nop */

--- a/main.c
+++ b/main.c
@@ -30,6 +30,8 @@
 
 #include "hping2.h"
 
+volatile struct delaytable_element delaytable[TABLESIZE];
+
 /* globals */
 unsigned int
 	tcp_th_flags = 0,


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: scan.o:/build/hping/hping2.h:360: multiple definition of `delaytable'; main.o:/build/hping/hping2.h:360: first defined here

The change moves variable definitions to .c file.