### PR TITLE
rtt: Fix extra 1 second delay in RTT calculation

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -20,8 +20,8 @@
 
 void inc_destparm(int sid)
 {
-	static long sec = 0;
-	static long usec = 0;
+	static struct timeval tv = {0, 0};
+	struct timeval tmptv;
 	int *p;
 	int errno_save = errno;
 
@@ -38,7 +38,9 @@ void inc_destparm(int sid)
 		return;
 	}
 
-	if ( (time(NULL) == sec) && ((get_usec() - usec) < 200000) ) {
+	gettimeofday(&tmptv, NULL);
+	if ( (tmptv.tv_sec == tv.tv_sec) &&
+	     ((tmptv.tv_usec - tv.tv_usec) < 200000) ) {
 		if (*p > 0)
 			(*p)-=2;
 		if (*p < 0)
@@ -50,8 +52,7 @@ void inc_destparm(int sid)
 	printf("%d: ", *p);
 	fflush(stdout);
 
-	sec = time(NULL);
-	usec = get_usec();
+	gettimeofday(&tv, NULL);
 	signal(SIGTSTP, inc_destparm);
 	errno = errno_save;
 }

--- a/getusec.c
+++ b/getusec.c
@@ -13,12 +13,14 @@
 #include <sys/time.h>
 #include <stdlib.h>
 
+/* A signed 32-bit integer can represent a maximum of 35 minutes
+ * when measured in microseconds. */
 time_t get_usec(void)
 {
 	struct timeval tmptv;
 
 	gettimeofday(&tmptv, NULL);
-	return tmptv.tv_usec;
+	return ((tmptv.tv_sec % 1800) * 1000000 + tmptv.tv_usec);
 }
 
 time_t milliseconds(void)

--- a/rtt.c
+++ b/rtt.c
@@ -32,6 +32,7 @@ int rtt(int *seqp, int recvport, float *ms_delay)
 {
 	long sec_delay = 0, usec_delay = 0;
 	int i, tablepos = -1, status;
+	struct timeval tmptv;
 
 	if (*seqp != 0) {
 		for (i = 0; i < TABLESIZE; i++)
@@ -54,10 +55,9 @@ int rtt(int *seqp, int recvport, float *ms_delay)
 		status = delaytable[tablepos].status;
 		delaytable[tablepos].status = S_RECV;
 
-		sec_delay = time(NULL) - delaytable[tablepos].sec;
-		usec_delay = get_usec() - delaytable[tablepos].usec;
-		if (sec_delay == 0 && usec_delay < 0)
-			usec_delay += 1000000;
+		gettimeofday(&tmptv, NULL);
+		sec_delay = tmptv.tv_sec - delaytable[tablepos].sec;
+		usec_delay = tmptv.tv_usec - delaytable[tablepos].usec;
 
 		*ms_delay = (sec_delay * 1000) + ((float)usec_delay / 1000);
 		minavgmax(*ms_delay);
@@ -74,11 +74,11 @@ int rtt(int *seqp, int recvport, float *ms_delay)
 		printf("\n\nSANITY CHECK in rtt.c FAILED!\n");
 		printf("- seqnum = %d\n", *seqp);
 		printf("- status = %d\n", status);
-		printf("- get_usec() = %ld\n", (long int) get_usec());
+		printf("- usec = %ld\n", tmptv.tv_usec);
 		printf("- delaytable.usec = %ld\n", 
                        (long int) delaytable[tablepos].usec);
 		printf("- usec_delay = %ld\n", usec_delay);
-		printf("- time(NULL) = %ld\n", (long int) time(NULL));
+		printf("- sec = %ld\n", tmptv.tv_sec);
 		printf("- delaytable.sec = %ld\n", 
                        (long int) delaytable[tablepos].sec);
 		printf("- sec_delay = %ld\n", sec_delay);

--- a/sendicmp.c
+++ b/sendicmp.c
@@ -67,6 +67,7 @@ void send_icmp_echo(void)
 {
 	char *packet, *data;
 	struct myicmphdr *icmp;
+	struct timeval tmptv;
 
 	packet = malloc(ICMPHDR_SIZE + data_size);
 	if (packet == NULL) {
@@ -96,8 +97,10 @@ void send_icmp_echo(void)
 		icmp->checksum = icmp_cksum;
 
 	/* adds this pkt in delaytable */
-	if (opt_icmptype == ICMP_ECHO)
-		delaytable_add(_icmp_seq, 0, time(NULL), get_usec(), S_SENT);
+	if (opt_icmptype == ICMP_ECHO) {
+		gettimeofday(&tmptv, NULL);
+		delaytable_add(_icmp_seq, 0, tmptv.tv_sec, tmptv.tv_usec, S_SENT);
+	}
 
 	/* send packet */
 	send_ip_handler(packet, ICMPHDR_SIZE + data_size);
@@ -111,6 +114,7 @@ void send_icmp_timestamp(void)
 	char *packet;
 	struct myicmphdr *icmp;
 	struct icmp_tstamp_data *tstamp_data;
+	struct timeval tmptv;
 
 	packet = malloc(ICMPHDR_SIZE + sizeof(struct icmp_tstamp_data));
 	if (packet == NULL) {
@@ -140,8 +144,10 @@ void send_icmp_timestamp(void)
 		icmp->checksum = icmp_cksum;
 
 	/* adds this pkt in delaytable */
-	if (opt_icmptype == ICMP_TIMESTAMP)
-		delaytable_add(_icmp_seq, 0, time(NULL), get_usec(), S_SENT);
+	if (opt_icmptype == ICMP_TIMESTAMP) {
+		gettimeofday(&tmptv, NULL);
+		delaytable_add(_icmp_seq, 0, tmptv.tv_sec, tmptv.tv_usec, S_SENT);
+	}
 
 	/* send packet */
 	send_ip_handler(packet, ICMPHDR_SIZE + sizeof(struct icmp_tstamp_data));
@@ -154,6 +160,7 @@ void send_icmp_address(void)
 {
 	char *packet;
 	struct myicmphdr *icmp;
+	struct timeval tmptv;
 
 	packet = malloc(ICMPHDR_SIZE + 4);
 	if (packet == NULL) {
@@ -180,8 +187,10 @@ void send_icmp_address(void)
 		icmp->checksum = icmp_cksum;
 
 	/* adds this pkt in delaytable */
-	if (opt_icmptype == ICMP_TIMESTAMP)
-		delaytable_add(_icmp_seq, 0, time(NULL), get_usec(), S_SENT);
+	if (opt_icmptype == ICMP_TIMESTAMP) {
+		gettimeofday(&tmptv, NULL);
+		delaytable_add(_icmp_seq, 0, tmptv.tv_sec, tmptv.tv_usec, S_SENT);
+	}
 
 	/* send packet */
 	send_ip_handler(packet, ICMPHDR_SIZE + 4);

--- a/sendtcp.c
+++ b/sendtcp.c
@@ -29,6 +29,7 @@ void send_tcp(void)
 	struct mytcphdr		*tcp;
 	struct pseudohdr	*pseudoheader;
 	unsigned char		*tstamp;
+	struct timeval tmptv;
 
 	if (opt_tcp_timestamp)
 		tcp_opt_size = 12;
@@ -86,7 +87,8 @@ void send_tcp(void)
 #endif
 
 	/* adds this pkt in delaytable */
-	delaytable_add(sequence, src_port, time(NULL), get_usec(), S_SENT);
+	gettimeofday(&tmptv, NULL);
+	delaytable_add(sequence, src_port, tmptv.tv_sec, tmptv.tv_usec, S_SENT);
 
 	/* send packet */
 	send_ip_handler(packet+PSEUDOHDR_SIZE, packet_size);

--- a/sendudp.c
+++ b/sendudp.c
@@ -29,6 +29,7 @@ void send_udp(void)
 	char			*packet, *data;
 	struct myudphdr		*udp;
 	struct pseudohdr *pseudoheader;
+	struct timeval tmptv;
 
 	packet_size = UDPHDR_SIZE + data_size;
 	packet = malloc(PSEUDOHDR_SIZE + packet_size);
@@ -65,7 +66,8 @@ void send_udp(void)
 #endif
 
 	/* adds this pkt in delaytable */
-	delaytable_add(sequence, src_port, time(NULL), get_usec(), S_SENT);
+	gettimeofday(&tmptv, NULL);
+	delaytable_add(sequence, src_port, tmptv.tv_sec, tmptv.tv_usec, S_SENT);
 
 	/* send packet */
 	send_ip_handler(packet+PSEUDOHDR_SIZE, packet_size);


### PR DESCRIPTION
Occasionally hping mis reports large RTT latency (>1000ms) . For more details: https://github.com/antirez/hping/issues/48
Thanks.


Fix the issue in the rtt() function where it incorrectly adds an extra 1 second delay to the RTT calculation. To ensure the acquisition of atomic seconds and microseconds values, use gettimeofday() instead of time() and get_usec().

**Trigger command:**
hping3 -S -p 6379 -c 1000  192.168.0.7   -i u10000
<img width="644" alt="image" src="https://github.com/antirez/hping/assets/4547441/b6d1813f-3fc1-472e-9f21-a1affdf06b1b">


**Error output:**
      On average, out of every 1000 ping packets, 1 to 2 times the RTT delay exceeds 1 second. This delay of more than 1 second is exactly 1 second longer compared to the delays of the packets before and after it.

<img width="698" alt="image" src="https://github.com/antirez/hping/assets/4547441/98f5ab1c-7774-4ad7-a4ac-11aa4912cf2a">


**tcpdump analysis:**
     The tcpdump capture shows that the TCP connection with cport 2570 and sport 6379 completed the three-way handshake in a total of 102 microseconds, which did not exceed 1 second.
<img width="866" alt="image" src="https://github.com/antirez/hping/assets/4547441/df7dfd43-f652-4712-915b-81f5061ab953">


**More detailed log analysis**
      This issue typically arises when there is a system time change between the two steps of fetching a timestamp. If a carry-over occurs between fetching seconds and microseconds, it indeed results in the seconds being 1 second less than the actual time. Modify the source code to print out some intermediate results within the rtt() function.

case1: The start time is incorrect, the end time is correct, and the time difference is incorrect. （note fixed）
Incorrect start time: 1719999425.000532s         Correct start time: 1719999426.000532s
Correct end time:     1719999426.002238s
Incorrect time difference:         1.001706s = **1001.7ms**         Correct time difference:           0.001706s = 1.7ms
<img width="700" alt="image" src="https://github.com/antirez/hping/assets/4547441/69e5fad2-cb25-4158-82dc-1e04d71774a8">


case2:  The start time is correct, the end time is incorrect, and the time difference is incorrect (partially fixed).
Correct start time: 1720000176.998808s
Incorrect end time: 1720000176.000237s     Correct end time: 1720000177.000237s
Incorrect time difference: -0.998571s           Correct time difference: 0.001429s = 1.4ms
<img width="659" alt="image" src="https://github.com/antirez/hping/assets/4547441/a453fd72-f8d4-45c0-9e4e-255df984b67d">


This situation has been partially fixed but not completely.
![image](https://github.com/antirez/hping/assets/4547441/3928b540-553a-4f06-b9be-7fcbc00e34c1)